### PR TITLE
Add and apply codespell config

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words-list = missings,rcall,linke,strat,nd,nodel
+skip = CITATIONS.bib,*.html

--- a/docs/src/examples/Ex103_PSC_IVMeasurement.md
+++ b/docs/src/examples/Ex103_PSC_IVMeasurement.md
@@ -55,16 +55,16 @@ function main(;n = 3, Plotter = PyPlot, plotting = false, verbose = false, test 
     if otherScanProtocol
         # scan protocol parameter
         number_tsteps = 40
-        frequence     = 10.0 * Hz
+        frequency     = 10.0 * Hz
         amplitude     = 0.2  * V
-        tend          = 1/frequence
+        tend          = 1/frequency
 
         # Define sinusoidal applied voltage
         function sinusoidalScanProtocol(t)
             if t == Inf
                 0.0
             else
-                amplitude * sin(2.0 * pi * frequence * t)
+                amplitude * sin(2.0 * pi * frequency * t)
             end
         end
 

--- a/docs/src/examples/Ex104_PSC_Photogeneration.md
+++ b/docs/src/examples/Ex104_PSC_Photogeneration.md
@@ -327,7 +327,7 @@ these values are needed for putting the generation slightly on
     end
     ################################################################################
 
-    # put here back the homogenous Neumann boundary conditions.
+    # put here back the homogeneous Neumann boundary conditions.
     ctsys.fvmsys.boundary_factors[iphia, bregionJ2] = 0.0
     ctsys.fvmsys.boundary_values[iphia, bregionJ2]  = 0.0
 

--- a/docs/src/examples/Ex108_CIGS_WithTraps.md
+++ b/docs/src/examples/Ex108_CIGS_WithTraps.md
@@ -11,7 +11,7 @@ using ChargeTransport
 using ExtendableGrids
 using PyPlot
 
-# function to initialize the grid for a possble extension to other p-i-n devices.
+# function to initialize the grid for a possible extension to other p-i-n devices.
 function initialize_pin_grid(refinementfactor, h_ndoping, h_pdoping_left, h_pdoping_trap, h_pdoing_right)
     coord_ndoping    = collect(range(0.0, stop = h_ndoping, length = 2 * refinementfactor))
     coord_pdoping_left  = collect(range(h_ndoping, stop = (h_ndoping + h_pdoping_left), length = 3 * refinementfactor))

--- a/docs/src/examples/Ex109_Traps.md
+++ b/docs/src/examples/Ex109_Traps.md
@@ -10,7 +10,7 @@ using ChargeTransport
 using ExtendableGrids
 using PyPlot
 
-# function to initialize the grid for a possble extension to other p-i-n devices.
+# function to initialize the grid for a possible extension to other p-i-n devices.
 function initialize_pin_grid(refinementfactor, h_ndoping, h_intrinsic, h_pdoping)
     coord_ndoping   = collect(range(0.0, stop = h_ndoping, length = 3 * refinementfactor))
     coord_intrinsic = collect(range(h_ndoping, stop = (h_ndoping + h_intrinsic), length = 3 * refinementfactor))

--- a/docs/src/examples/Ex201_PSC_tensorGrid.md
+++ b/docs/src/examples/Ex201_PSC_tensorGrid.md
@@ -87,7 +87,7 @@ function main(;n = 3, Plotter = PyPlot, plotting = false, verbose = false, test 
     cellmask!(grid, [h_pdoping, 0.0],               [h_ndoping + h_intrinsic, height], regionIntrinsic, tol = 1.0e-18)
     cellmask!(grid, [h_ndoping + h_intrinsic, 0.0], [h_total, height],                 regionAcceptor, tol = 1.0e-18)
 
-    # specifiy outer regions
+    # specify outer regions
     # metal interfaces
     bfacemask!(grid, [0.0, 0.0], [0.0, height], bregionDonor)            # BregionNumber = 1
     bfacemask!(grid, [h_total, 0.0], [h_total, height], bregionAcceptor) # BregionNumber = 2

--- a/examples/Ex103_PSC_IVMeasurement.jl
+++ b/examples/Ex103_PSC_IVMeasurement.jl
@@ -60,16 +60,16 @@ function main(;n = 3, Plotter = PyPlot, plotting = false, verbose = false, test 
     if otherScanProtocol
         ## scan protocol parameter
         number_tsteps = 40
-        frequence     = 10.0 * Hz
+        frequency     = 10.0 * Hz
         amplitude     = 0.2  * V
-        tend          = 1/frequence
+        tend          = 1/frequency
 
         ## Define sinusoidal applied voltage
         function sinusoidalScanProtocol(t)
             if t == Inf
                 0.0
             else
-                amplitude * sin(2.0 * pi * frequence * t)
+                amplitude * sin(2.0 * pi * frequency * t)
             end
         end
 

--- a/examples/Ex104_PSC_Photogeneration.jl
+++ b/examples/Ex104_PSC_Photogeneration.jl
@@ -338,7 +338,7 @@ function main(;n = 5,
     end
     ################################################################################
 
-    ## put here back the homogenous Neumann boundary conditions.
+    ## put here back the homogeneous Neumann boundary conditions.
     ctsys.fvmsys.boundary_factors[iphia, bregionJ2] = 0.0
     ctsys.fvmsys.boundary_values[iphia, bregionJ2]  = 0.0
 

--- a/examples/Ex108_CIGS_WithTraps.jl
+++ b/examples/Ex108_CIGS_WithTraps.jl
@@ -12,7 +12,7 @@ using ChargeTransport
 using ExtendableGrids
 using PyPlot
 
-## function to initialize the grid for a possble extension to other p-i-n devices.
+## function to initialize the grid for a possible extension to other p-i-n devices.
 function initialize_pin_grid(refinementfactor, h_ndoping, h_pdoping_left, h_pdoping_trap, h_pdoing_right)
     coord_ndoping    = collect(range(0.0, stop = h_ndoping, length = 2 * refinementfactor))
     coord_pdoping_left  = collect(range(h_ndoping, stop = (h_ndoping + h_pdoping_left), length = 3 * refinementfactor))

--- a/examples/Ex109_Traps.jl
+++ b/examples/Ex109_Traps.jl
@@ -11,7 +11,7 @@ using ChargeTransport
 using ExtendableGrids
 using PyPlot
 
-## function to initialize the grid for a possble extension to other p-i-n devices.
+## function to initialize the grid for a possible extension to other p-i-n devices.
 function initialize_pin_grid(refinementfactor, h_ndoping, h_intrinsic, h_pdoping)
     coord_ndoping   = collect(range(0.0, stop = h_ndoping, length = 3 * refinementfactor))
     coord_intrinsic = collect(range(h_ndoping, stop = (h_ndoping + h_intrinsic), length = 3 * refinementfactor))

--- a/examples/Ex201_PSC_tensorGrid.jl
+++ b/examples/Ex201_PSC_tensorGrid.jl
@@ -89,7 +89,7 @@ function main(;n = 3, Plotter = PyPlot, plotting = false, verbose = false, test 
     cellmask!(grid, [h_pdoping, 0.0],               [h_ndoping + h_intrinsic, height], regionIntrinsic, tol = 1.0e-18)
     cellmask!(grid, [h_ndoping + h_intrinsic, 0.0], [h_total, height],                 regionAcceptor, tol = 1.0e-18)
 
-    ## specifiy outer regions
+    ## specify outer regions
     ## metal interfaces
     bfacemask!(grid, [0.0, 0.0], [0.0, height], bregionDonor)            # BregionNumber = 1
     bfacemask!(grid, [h_total, 0.0], [h_total, height], bregionAcceptor) # BregionNumber = 2

--- a/pluto-examples/PSC_example.jl
+++ b/pluto-examples/PSC_example.jl
@@ -477,7 +477,7 @@ begin
 
     end # generation loop
 	#############################################################
-	## put here back the homogenous Neumann boundary conditions.
+	## put here back the homogeneous Neumann boundary conditions.
     ctsys.fvmsys.boundary_factors[iphia, bregionJunction2] = 0.0
     ctsys.fvmsys.boundary_values[iphia, bregionJunction2]  = 0.0
 
@@ -878,7 +878,7 @@ begin
 
         end # generation loop
 
-        ## put here back the homogenous Neumann boundary conditions.
+        ## put here back the homogeneous Neumann boundary conditions.
         ctsys.fvmsys.boundary_factors[iphia, bregionJunction2] = 0.0
         ctsys.fvmsys.boundary_values[iphia, bregionJunction2]  = 0.0
 

--- a/src/ct_physics.jl
+++ b/src/ct_physics.jl
@@ -440,8 +440,9 @@ Creates Schottky boundary conditions. For the electrostatic potential we assume
 
 ``\\psi = - \\phi_S/q + U, ``
 
-where  ``\\phi_S`` corresponds to a given value (non-negative Schottky barrier) and ``U`` to the applied voltage. The quantitity ``\\phi_S`` needs to be specified in the main file.
-For eletrons and holes we assume the following
+where  ``\\phi_S`` corresponds to a given value (non-negative Schottky barrier) and ``U`` to the applied voltage. 
+The quantity ``\\phi_S`` needs to be specified in the main file.
+For electrons and holes we assume the following
 
 ``f[n_\\alpha]  =  z_\\alpha q v_\\alpha (n_\\alpha - n_{\\alpha, 0})``,
 
@@ -492,8 +493,9 @@ A mixed Schottky-Ohmic boundary type condition, where we impose on the electric 
 
 ``\\psi = - \\phi_S/q + U, ``
 
-with  ``\\phi_S`` as given value (non-negative Schottky barrier) and ``U`` to the applied voltage. The quantitity ``\\phi_S`` needs to be specified in the main file.
-For eletrons and holes we assume the following (Ohmic)
+with  ``\\phi_S`` as given value (non-negative Schottky barrier) and ``U`` to the applied voltage. 
+The quantity ``\\phi_S`` needs to be specified in the main file.
+For electrons and holes we assume the following (Ohmic)
 
 `` \\varphi_{\\alpha} = U``.
 """

--- a/src/ct_system.jl
+++ b/src/ct_system.jl
@@ -605,7 +605,7 @@ mutable struct Data{TFuncs<:Function, TVoltageFunc<:Function, TGenerationData<:U
 
     """
     An datatype containing the information, whether at least on quasi Fermi potential is
-    assumend to be continuous or discontinuous.
+    assumed to be continuous or discontinuous.
     """
     qFModel                      ::  QFModelType
 
@@ -616,7 +616,7 @@ mutable struct Data{TFuncs<:Function, TVoltageFunc<:Function, TGenerationData<:U
     boundaryType                 ::  Array{BoundaryModelType, 1}
 
     """
-    An array containing predefined functions for the applied bias in dependance of time
+    An array containing predefined functions for the applied bias in dependence of time
     at each outer boundary.
     """
     contactVoltageFunction       ::  Array{TVoltageFunc, 1}
@@ -627,8 +627,9 @@ mutable struct Data{TFuncs<:Function, TVoltageFunc<:Function, TGenerationData<:U
     bulkRecombination            ::  BulkRecombination
 
     """
-    A function/Array containing the user-specific photogeneration rate. It can be a function
-    which is specified in the user example or an array which is read in and calculatd with,
+    A function/Array containing the user-specific photogeneration rate. 
+    It can be a function which is specified in the user example 
+    or an array which is read in and calculated with,
     e.g., an external software.
     """
     generationData               ::  TGenerationData
@@ -733,7 +734,7 @@ mutable struct Data{TFuncs<:Function, TVoltageFunc<:Function, TGenerationData<:U
     ###############################################################
 
     """
-    Within this template informations concerning the band-edge energy
+    Within this template, information concerning the band-edge energy
     of each carrier is stored locally which saves allocations.
     We have two of such templates due to the two point flux approximation schemes.
     """
@@ -745,14 +746,14 @@ mutable struct Data{TFuncs<:Function, TVoltageFunc<:Function, TGenerationData<:U
     tempBEE2                     ::  Array{Float64, 1}
 
     """
-    Within this template informations concerning the effective DOS
+    Within this template, information concerning the effective DOS
     of each carrier is stored locally which saves allocations.
     We have two of such templates due to the two point flux approximation schemes.
     """
     tempDOS1                     ::  Array{Float64, 1}
 
     """
-    See the desciption of tempDOS2.
+    See the description of tempDOS2.
     """
     tempDOS2                     ::  Array{Float64, 1}
 
@@ -1532,7 +1533,7 @@ function get_current_val(ctsys, U, Uold, Δt) # DA: But caution, still need some
         current = current + I[ii]
     end
 
-    # DA: caution I[ipsi] not completly correct. In our examples, this does not effect something,
+    # DA: caution I[ipsi] not completely correct. In our examples, this does not effect something,
     # but we need derivative here.
     return current
 end
@@ -1586,7 +1587,7 @@ $(TYPEDSIGNATURES)
 Compute the electro-neutral solution for the Boltzmann approximation.
 It is obtained by setting the left-hand side in
 the Poisson equation equal to zero and solving for ``\\psi``.
-The charge carriers may obey different statitics functions.
+The charge carriers may obey different statistics functions.
 Currently, this one is not well tested for the case of charge carriers beyond electrons and holes.
 """
 function electroNeutralSolution(ctsys)
@@ -1661,7 +1662,7 @@ end
 $(TYPEDSIGNATURES)
 
 First try of debugger. Print the Jacobi matrix for a given node, i.e. the number of node in
-the grid and not the excact coordinate. This is only done for the one dimensional case so far.
+the grid and not the exact coordinate. This is only done for the one dimensional case so far.
 """
 function printJacobi(node, sys)
     ctdata = data(sys)


### PR DESCRIPTION
This configures codespell, a tool to detect common typos.
The `.codespellrc` defined which typos should not be checked for 
and which files should be ignored.