### PR TITLE
Method to calculate the vacancy energy level internally via the Brent method

### DIFF
--- a/examples/Ex103_PSC_IVMeasurement.jl
+++ b/examples/Ex103_PSC_IVMeasurement.jl
@@ -23,7 +23,7 @@ using PyPlot
 function main(;
         n = 3, Plotter = PyPlot, plotting = false, verbose = false, test = false,
         parameter_set = Params_PSC_TiO2_MAPI_spiro, # choose the parameter set
-        otherScanProtocol = false
+        otherScanProtocol = false, EaPredefined = true,
     ) # you can choose between two scan protocols
 
     @local_unitfactors μm cm s ns V K ps Hz
@@ -197,6 +197,10 @@ function main(;
 
     data.params = Params(p)
 
+    if EaPredefined
+        data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] = p.Ea[p.regionIntrinsic]
+    end
+
     ctsys = System(grid, data, unknown_storage = :sparse)
 
     if test == false
@@ -305,6 +309,10 @@ function main(;
         inival = solution
 
     end # time loop
+
+    integral = integrated_density(ctsys, sol = solution, icc = p.iphia, ireg = p.regionIntrinsic)
+
+    println("Calculated average vacancy density is: ", integral/data.regionVolumes[p.regionIntrinsic])
 
     if test == false
         println("*** done\n")

--- a/examples/Ex103_PSC_IVMeasurement.jl
+++ b/examples/Ex103_PSC_IVMeasurement.jl
@@ -244,6 +244,12 @@ function main(;
     solution = equilibrium_solve!(ctsys, control = control)
     inival = solution
 
+    if !EaPredefined
+        calculate_Ea!(ctsys, inival = inival, control = control)
+
+        inival = solve(ctsys, inival = inival, control = control)
+    end
+
     if plotting
         Plotter.figure()
         plot_energies(Plotter, ctsys, solution, "Equilibrium", label_energy)
@@ -310,10 +316,6 @@ function main(;
 
     end # time loop
 
-    integral = integrated_density(ctsys, sol = solution, icc = p.iphia, ireg = p.regionIntrinsic)
-
-    println("Calculated average vacancy density is: ", integral/data.regionVolumes[p.regionIntrinsic])
-
     if test == false
         println("*** done\n")
     end
@@ -352,6 +354,16 @@ function main(;
         PyPlot.ylabel("current density [mAcm\$^{-2} \$]")
     end
 
+    if test == false
+        integral = integrated_density(ctsys, sol = solution, icc = p.iphia, ireg = p.regionIntrinsic)
+
+        println("Calculated average vacancy density is: ", integral/data.regionVolumes[p.regionIntrinsic])
+        println(" ")
+        if test == false
+            println("Value for vacancy energy is: ", data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic]/data.constants.q, " eV. Save this value for later use.")
+            println(" ")
+        end
+    end
     testval = sum(filter(!isnan, solution)) / length(solution) # when using sparse storage, we get NaN values in solution
     return testval
 
@@ -359,8 +371,8 @@ function main(;
 end #  main
 
 function test()
-    testval = -0.6302819608784171; testvalOther = -1.123710261723505
-    return main(test = true, otherScanProtocol = false) ≈ testval && main(test = true, otherScanProtocol = true) ≈ testvalOther
+    testval = -0.6321523352492795; testvalOther = -1.1216629981577289; testNotPredefined = -0.632152335248958
+    return main(test = true, otherScanProtocol = false) ≈ testval && main(test = true, otherScanProtocol = true) ≈ testvalOther && main(test = true, otherScanProtocol = false, EaPredefined = false) ≈ testNotPredefined
 end
 
 if test == false

--- a/parameter_files/Params_PSC_TiO2_MAPI_spiro.jl
+++ b/parameter_files/Params_PSC_TiO2_MAPI_spiro.jl
@@ -135,7 +135,6 @@ function Params(p::Params_PSC_TiO2_MAPI_spiro)
 
         params.bandEdgeEnergy[p.iphin, ireg] = p.En[ireg]
         params.bandEdgeEnergy[p.iphip, ireg] = p.Ep[ireg]
-        params.bandEdgeEnergy[p.iphia, ireg] = p.Ea[ireg]
 
         params.mobility[p.iphin, ireg] = p.μn[ireg]
         params.mobility[p.iphip, ireg] = p.μp[ireg]

--- a/parameter_files/Params_PSC_TiO2_MAPI_spiro.jl
+++ b/parameter_files/Params_PSC_TiO2_MAPI_spiro.jl
@@ -66,7 +66,7 @@
     ## band edge energies
     En = [-4.0, -3.7, -3.4] .* eV
     Ep = [-5.8, -5.4, -5.1] .* eV
-    Ea = [0.0, -4.45, 0.0] .* eV
+    Ea = [0.0, -4.4351, 0.0] .* eV
     Ea_i = Ea[regionIntrinsic]
 
     ## effective densities of density of states

--- a/src/ChargeTransport.jl
+++ b/src/ChargeTransport.jl
@@ -107,7 +107,7 @@ export set_contact!
 export compute_open_circuit_voltage
 export electroNeutralSolution
 export show_params, show_paramsoptical, trap_density
-export get_current_val, charge_density
+export get_current_val, charge_density, integrated_density
 
 ##################################################################
 

--- a/src/ChargeTransport.jl
+++ b/src/ChargeTransport.jl
@@ -95,7 +95,7 @@ export BulkRecombination, set_bulk_recombination
 
 export enable_ionic_carrier!
 
-export equilibrium_solve!
+export equilibrium_solve!, calculate_Ea!
 export enable_species!, enable_boundary_species!
 export solve
 export unknowns, NewtonControl, SolverControl


### PR DESCRIPTION
## Summary
This feature makes it possible to calculate the **vacancy energy level** for perovskite solar cell applications internally.  
It has been tested in one example so far.

---

## Still To Do
- [ ] Test with additional perovskite examples and adjust as needed  
- [ ] Add a motivating section in the documentation  
- [ ] Update changelog and bump version  

---

## New Features
- [ ] Added method `calculate_Ea!`  
  → Directly computes the correct energy level such that the average vacancy density matches the user-defined target  

- [ ] Added method `integrated_density`  
  → Computes the integrated carrier density for a given species `icc` and region `ireg`  

- [ ] Extended `Data` structure with `data.regionVolumes`  
  → Stores the volume (measure) of each subregion  

---

## Example Usage

```julia
# Compute vacancy energy level automatically
calculate_Ea!(ctsys, inival = inival, control = control)

# new solution based on internally saved new energy
inival = solve(ctsys, inival = inival, control = control)

# Compute integrated density for a carrier species, e.g.
n_int = integrated_density(ctsys, sol = inival, icc = p.iphia, ireg = p.regionIntrinsic)

println("Vacancy energy level: ", data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic]/data.constants.q) # in eV.
println("Integrated density: ", n_int/data.regionVolumes[p.regionIntrinsic])
