### PR TITLE
Feature to calculate the vacancy energy level internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -----------------------------------------------------------------------------------------------
+## v1.2.1
+
+### Added
+  - Modified `equilibrium_solve!()`. Directly computes now the correct energy level such that the average vacancy density matches the user-defined target, if the argument is `vacancyEnergyCalculation = true`. Check the [package documentation](https://wias-pdelib.github.io/ChargeTransport.jl/stable/PSC/) for more information
+  - Added method integrated_density, which computes the integrated carrier density for a given species `icc` and region `ireg`
+  - Extended Data structure with `data.regionVolumes`, which stores the volume (measure) of each subregion
 
 ## v1.1.0
 
-### Fixed 
+### Fixed
   - fixed broken v1.0.0 release
-
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added method integrated_density, which computes the integrated carrier density for a given species `icc` and region `ireg`
   - Extended Data structure with `data.regionVolumes`, which stores the volume (measure) of each subregion
 
+### Changed
+  - loop for increasing photogeneration rate is now also included internally, see Ex103. There is now no need to do this by the user.
+
 ## v1.1.0
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChargeTransport"
 uuid = "25c3eafe-d88c-11e9-3031-f396758f002a"
-version = "1.1.1"
+version = "1.2.1"
 authors = ["Dilara Abdel <dilara.abdel@wias-berlin.de>, Patricio Farrell <patricio.farrell@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Version 1.0.0 introduces several important changes to improve the package's usab
 - **New Parameter System**: Parameter files are replaced by parameter structs with explicit access (e.g., `p = parameter_set(); p.foo`)
 - **Unit Handling**: Global unit factors are removed in favor of local unit factors from `LessUnitful.jl` (`@local_unitfactors` and `ufac""`)
 - **Constants Management**: New globally available dimensionless `constants` object for physical constants
-- **API Changes**: 
+- **API Changes**:
   - `Data` type now takes a `constants` object as key word argument, defaults to standard constants.
   - Thermal voltage `UT` is removed from `Params` and replaced with temperature in relevant methods
   - `eV` not available any more, use explicit `eV = q * V` if needed
@@ -51,11 +51,10 @@ Version 1.0.0 introduces several important changes to improve the package's usab
 
 [6.] D. Abdel, A. Glitzky and M. Liero. [Analysis of a drift-diffusion model for perovskite solar cells.](https://doi.org/10.3934/dcdsb.2024081) Discrete and Continuous Dynamical Systems - Series B (2024).
 
-[7.] D. Abdel, M. Herda, M. Ziegler, C. Chainais-Hillairet, B. Spetzler, P. Farrell. [Numerical analysis and simulation of lateral memristive devices: Schottky, ohmic, and multi-dimensional electrode models.]( 	
+[7.] D. Abdel, M. Herda, M. Ziegler, C. Chainais-Hillairet, B. Spetzler, P. Farrell. [Numerical analysis and simulation of lateral memristive devices: Schottky, ohmic, and multi-dimensional electrode models.](
 https://doi.org/10.48550/arXiv.2412.15065
 ) submitted (2024).
 
-[8.] B. Spetzler, E. Spetzler, S. Zamankhani, D. Abdel, P. Farrell, K.-U. Sattler, M. Ziegler. [Physics-Guided Sequence Modeling for Fast Simulation and Design Exploration of 2D Memristive Devices.](https://doi.org/10.48550/arXiv.2505.13882
-) (2025).
+[8.] B. Spetzler, E. Spetzler, S. Zamankhani, D. Abdel, P. Farrell, K.-U. Sattler, M. Ziegler. [Physics-Guided Sequence Modeling for Fast Simulation and Design Exploration of 2D Memristive Devices.](https://doi.org/10.48550/arXiv.2505.13882) submitted (2025).
 
 [9.] D. Abdel, J. Relle, T. Kirchartz, P. Jaap, J. Fuhrmann, S. Burger, C. Becker, K. Jäger, P. Farrell. [Unravelling the mystery of enhanced open-circuit voltages in nanotextured perovskite solar cells.](https://doi.org/10.48550/arXiv.2506.10691) submitted (2025).

--- a/docs/src/PSC.md
+++ b/docs/src/PSC.md
@@ -33,9 +33,65 @@ Differences to the previous example include
 - a generation rate $G$
 - higher dimensional problem.
 
-A quick survey on how to use `ChargeTransport.jl` to adjust the input parameters such that these features can be simulated will be given in the following.
+# Simulating electronic-ionic charge transport
 
-## Example 1: Graded interfaces
+For example, for perovskite solar cells an average vacancy density is given in literature.
+If the charge carrier densities are used as the set of unknowns, the initial condition for the anion vacancy density can be given by
+
+$$
+n_{\text{a}}^0 = C_{\text{a}},
+$$
+
+where $C_{\text{a}}$ corresponds to the uniform density of cation vacancies and is set equal to the average anion vacancy density to ensure global charge neutrality.
+With homogeneous no-flow Neumann boundary conditions around the perovskite layer for the anion vacancies, the total mass of anions is conserved at all times, i.e.
+
+$$
+\frac{1}{|\Omega_{\text{PVK}} |} \int_{\Omega_{\text{PVK}}} n_{\text{a}} (\mathbf{x}, t)\, d\mathbf{x}
+= \frac{1}{|\Omega_{\text{PVK}} |}  \int_{\Omega_{\text{PVK}}} n_{\text{a}}^0 (\mathbf{x})\, d\mathbf{x}
+= C_{\text{a}}, \quad \text{for all} \quad t \geq 0.
+$$
+
+Since we do not use charge carrier densities directly but instead employ quasi Fermi potentials as the unknowns, due to mathematical, physical, and numerical advantages, we must find a workaround to properly fix the initial condition for the vacancy density.
+
+## Quasi Fermi potential notation
+
+The statistical relation between the vacancy density and the potentials (our chosen unknowns) reads
+
+$$
+n_{\text{a}}  = N_{\text{a}}  F_{-1} \Bigl(\eta_{\text{a}} (\psi, \varphi_{\text{a}} ) \Bigr), \quad \eta_{\text{a}}  = z_{\text{a}}  \frac{q (\varphi_{\text{a}}  - \psi) + E_{\text{a}} }{k_B T},
+$$
+
+where $N_{\text{a}}$ denotes the maximum vacancy density allowed, $F_{-1} = (\exp(-x) +1)^{-1}$ is the Fermi-Dirac integral of order $-1$, and we refer to $E_{\text{a}}$ is the intrinsic vacancy energy level (somehow a model parameter).
+In equilibrium, we set the vacancy quasi-Fermi potential to zero, i.e., $\varphi_{\text{a}} = 0$, when the applied voltage is $V = 0$.
+Because the initial condition for the vacancy density is prescribed as $C_\text{a}$ and the electric potential $\psi$ is an unknown, the only remaining free parameter is the vacancy energy $E_{\text{a}}$.
+> The value of $E_{\text{a}}$ must be chosen such that the average vacancy density remains conserved for all time steps.
+
+## Current way of handling $E_\text{a}$
+
+We implement a method that calculates the appropriate `Ea` values internally via the secant method.
+To make use of this feature, you can add in the equilibrium solving the flag `vacancyEnergyCalculation=true`.
+
+```julia
+solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = true)
+```
+To check, if, indeed, the average vacancy density is maintained, you can calculate that value and print the chosen vacancy energy level.
+```julia
+integral = integrated_density(ctsys, sol = solution, icc = p.iphia, ireg = p.regionIntrinsic)
+
+println("Calculated average vacancy density is: ", integral / data.regionVolumes[p.regionIntrinsic])
+
+vacancyEnergy = data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] / data.constants.q
+println("Value for vacancy energy is: ", vacancyEnergy, " eV")
+```
+## Remarks
+
+- For **1D simulations**, this approach is sufficient.
+- For **multi-dimensional simulations**, however, we recommend precomputing the `Ea` values and storing them for later use.
+
+
+Next, we give a quick survey on how to use `ChargeTransport.jl` to adjust the input parameters such that all mentioned features can be simulated will be given in the following.
+
+# Example 1: Graded interfaces
 By default, we assume abrupt inner interfaces. If one wishes to simulate graded interfaces, where for example the effective density of states and the band-edge energy may vary, we refer to [this](https://github.com/WIAS-PDELib/ChargeTransport.jl/blob/master/examples/Ex105_PSC_gradedFlux.jl) example.
 
 We sketch the relevant parts here.

--- a/docs/src/PSC.md
+++ b/docs/src/PSC.md
@@ -1,7 +1,7 @@
 Perovskite solar cell
 ================================
 We simulate charge transport in perovskite solar cells (PSCs), where we have apart from holes and electrons also ionic charge carriers. Here, we assume to have three domains, denoted by
-$\mathbf{\Omega} = \mathbf{\Omega}_{\text{HTL}} \cup \mathbf{\Omega}_{\text{intr}} \cup \mathbf{\Omega}_{\text{ETL}}  $.
+$\mathbf{\Omega} = \mathbf{\Omega}_{\text{HTL}} \cup \mathbf{\Omega}_{\text{PVK}} \cup \mathbf{\Omega}_{\text{ETL}}  $.
 The unknowns are the quasi Fermi potentials of electrons, holes and anion vacancies
 $\varphi_n, \varphi_p, \varphi_a$
 as well as the electric potential
@@ -9,19 +9,19 @@ $\psi$.
 The underlying PDEs are given by
 ```math
 \begin{aligned}
-	- \nabla \cdot (\varepsilon_s \nabla \psi) &= q \Big( (p(\psi, \varphi_p) - C_p ) - (n(\psi, \varphi_n) - C_n) \Big),\\
-	q \partial_t n(\psi, \varphi_n) - \nabla \cdot \mathbf{j}_n &= q\Bigl(G(\mathbf{x}) - R(n,p) \Bigr), \\
-	q \partial_t p(\psi, \varphi_p) + \nabla \cdot \mathbf{j}_p &= \Bigl(G(\mathbf{x}) - R(n,p) \Bigr),
+	- \nabla \cdot (\varepsilon_s \nabla \psi) &= q \Big( (n_\text{p}(\psi, \varphi_\text{p}) - C_\text{p} ) - (n_\text{n}(\psi, \varphi_\text{n}) - C_\text{n}) \Big),\\
+	q \partial_t n_\text{n}(\psi, \varphi_\text{n}) - \nabla \cdot \mathbf{j}_\text{n} &= q\Bigl(G(\mathbf{x}) - R(n_\text{n},n_\text{p}) \Bigr), \\
+	q \partial_t n_\text{p}(\psi, \varphi_\text{p}) + \nabla \cdot \mathbf{j}_\text{p} &= \Bigl(G(\mathbf{x}) - R(n_\text{n},n_\text{p}) \Bigr),
 \end{aligned}
 ```
 for
-$\mathbf{x} \in \mathbf{\Omega}_{\text{HTL}} \cup  \mathbf{\Omega}_{\text{ETL}} $, $t \in [0, t_F]$. In the middle, intrinsic region ($ \mathbf{x} \in \mathbf{\Omega}_{\text{intr}} $), we have
+$\mathbf{x} \in \mathbf{\Omega}_{\text{HTL}} \cup  \mathbf{\Omega}_{\text{ETL}} $, $t \in [0, t_F]$. In the middle, intrinsic region ($ \mathbf{x} \in \mathbf{\Omega}_{\text{PVK}} $), we have
 ```math
 \begin{aligned}
-	- \nabla \cdot (\varepsilon_s \nabla \psi) &= q \Big( p(\psi, \varphi_p)  - n(\psi, \varphi_n) + a(\psi, \varphi_a) - C_a \Big),\\
-q \partial_t n(\psi, \varphi_n)	- \nabla \cdot \mathbf{j}_n &= \Bigl(G(\mathbf{x}) - R(n,p) \Bigr), \\
-	q \partial_t p(\psi, \varphi_p) + \nabla \cdot \mathbf{j}_p &= \Bigl(G(\mathbf{x}) - R(n,p) \Bigr),\\
-	q \partial_t a(\psi, \varphi_a) + \nabla \cdot \mathbf{j}_a &= 0,
+	- \nabla \cdot (\varepsilon_s \nabla \psi) &= q \Big( n_\text{p}(\psi, \varphi_\text{p})  - n_\text{n}(\psi, \varphi_\text{n}) + n_\text{a}(\psi, \varphi_\text{a}) - C_\text{a} \Big),\\
+q \partial_t n_\text{n}(\psi, \varphi_\text{n})	- \nabla \cdot \mathbf{j}_\text{n} &= \Bigl(G(\mathbf{x}) - R(n_\text{n},n_\text{p}) \Bigr), \\
+	q \partial_t n_\text{p}(\psi, \varphi_\text{p}) + \nabla \cdot \mathbf{j}_\text{p} &= \Bigl(G(\mathbf{x}) - R(n_\text{n},n_\text{p}) \Bigr),\\
+	q \partial_t n_\text{a}(\psi, \varphi_\text{a}) + \nabla \cdot \mathbf{j}_\text{a} &= 0,
 \end{aligned}
 ```
 see [Abdel2021](https://www.sciencedirect.com/science/article/abs/pii/S0013468621009865).
@@ -76,17 +76,17 @@ solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation
 ```
 To check, if, indeed, the average vacancy density is maintained, you can calculate that value and print the chosen vacancy energy level.
 ```julia
-integral = integrated_density(ctsys, sol = solution, icc = p.iphia, ireg = p.regionIntrinsic)
+integral = integrated_density(ctsys, sol = solution, icc = iphia, ireg = regionIntrinsic)
 
-println("Calculated average vacancy density is: ", integral / data.regionVolumes[p.regionIntrinsic])
+println("Calculated average vacancy density is: ", integral / data.regionVolumes[regionIntrinsic])
 
-vacancyEnergy = data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] / data.constants.q
+vacancyEnergy = data.params.bandEdgeEnergy[iphia, regionIntrinsic] / data.constants.q
 println("Value for vacancy energy is: ", vacancyEnergy, " eV")
 ```
 ## Remarks
 
 - For **1D simulations**, this approach is sufficient.
-- For **multi-dimensional simulations**, however, we recommend precomputing the `Ea` values and storing them for later use.
+- For **multi-dimensional simulations**, however, we recommend precomputing the `Ea` values and storing them in case of multiple computations with the same parameter set.
 
 
 Next, we give a quick survey on how to use `ChargeTransport.jl` to adjust the input parameters such that all mentioned features can be simulated will be given in the following.

--- a/examples/Ex104_PSC_Photogeneration.jl
+++ b/examples/Ex104_PSC_Photogeneration.jl
@@ -254,40 +254,6 @@ function main(;
     ## calculate equilibrium solution and as initial guess
     solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = vacancyEnergyCalculation)
     inival = solution
-
-    if test == false
-        println("*** done\n")
-    end
-
-    ################################################################################
-    if test == false
-        println("Loop for generation")
-    end
-    ################################################################################
-
-    # these values are needed for putting the generation slightly on
-    I = collect(20:-1:0.0)
-    LAMBDA = 10 .^ (-I)
-
-    ## since the constant which represents the constant quasi Fermi potential of anion vacancies is undetermined, we need
-    ## to fix it in the bias loop, since we have no applied bias. Otherwise we get convergence errors
-    ctsys.fvmsys.boundary_factors[p.iphia, p.bregionJ2] = 1.0e30
-    ctsys.fvmsys.boundary_values[p.iphia, p.bregionJ2] = 0.0
-
-    for istep in 1:(length(I) - 1)
-
-        ## turn slowly generation on
-        ctsys.data.λ2 = LAMBDA[istep + 1]
-
-        if test == false
-            println("increase generation with λ2 = $(data.λ2)")
-        end
-
-        solution = solve(ctsys, inival = inival, control = control)
-        inival = solution
-
-    end # generation loop
-
     solutionEQ = inival
 
     if plotting

--- a/examples/Ex104_PSC_Photogeneration.jl
+++ b/examples/Ex104_PSC_Photogeneration.jl
@@ -27,7 +27,7 @@ function main(;
         parameter_set = Params_PSC_TiO2_MAPI_spiro, # choose the parameter set
         ########################
         userdefinedGeneration = false,              # you can choose between predefined and user-defined generation profiles
-        EaPredefined = false,                       # assume the vacancy energy level is either on or off
+        vacancyEnergyCalculation = true,            # assume the vacancy energy level is either given or not
     )
 
     @local_unitfactors μm cm s ns V K ps Hz W m
@@ -219,7 +219,7 @@ function main(;
 
     data.params = Params(p)
 
-    if EaPredefined
+    if !vacancyEnergyCalculation
         data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] = p.Ea[p.regionIntrinsic]
     end
 
@@ -252,13 +252,8 @@ function main(;
     ################################################################################
 
     ## calculate equilibrium solution and as initial guess
-    solution = equilibrium_solve!(ctsys, control = control)
+    solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = vacancyEnergyCalculation)
     inival = solution
-
-    if !EaPredefined
-        calculate_Ea!(ctsys, control = control)
-        inival = equilibrium_solve!(ctsys, control = control)
-    end
 
     if test == false
         println("*** done\n")
@@ -474,7 +469,7 @@ function main(;
 
         println("Calculated average vacancy density is: ", integral / data.regionVolumes[p.regionIntrinsic])
         println(" ")
-        if !EaPredefined
+        if vacancyEnergyCalculation
             vacancyEnergy = data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] / data.constants.q
             println("Value for vacancy energy is: ", vacancyEnergy, " eV. Save this value for later use.")
             println("We recommend to calculate it on a fine grid.")
@@ -488,8 +483,8 @@ function main(;
 end #  main
 
 function test()
-    testval = -1.0451771259505067; testvalEaPredefined = -1.046195159158462
-    return main(test = true, EaPredefined = false) ≈ testval && main(test = true, EaPredefined = true) ≈ testvalEaPredefined && main(test = true, userdefinedGeneration = true) ≈ testval
+    testval = -1.0451771259505067; testvalvacancyEnergyCalculation = -1.046195159158462
+    return main(test = true, vacancyEnergyCalculation = true) ≈ testval && main(test = true, vacancyEnergyCalculation = false) ≈ testvalvacancyEnergyCalculation && main(test = true, userdefinedGeneration = true) ≈ testval
 end
 
 end # module

--- a/examples/Ex106_PSC_SurfaceRecombination.jl
+++ b/examples/Ex106_PSC_SurfaceRecombination.jl
@@ -19,7 +19,7 @@ function main(;
         n = 6, Plotter = PyPlot, plotting = false,
         verbose = false, test = false,
         parameter_set = Params_PSC_PCBM_MAPI_Pedot, # choose the parameter set
-        EaPredefined = false,                       # assume the vacancy energy level is either on or off
+        vacancyEnergyCalculation = false,           # assume the vacancy energy level is either given or not
     )
 
     if plotting
@@ -162,7 +162,7 @@ function main(;
 
     data.params = Params(p)
 
-    if EaPredefined
+    if !vacancyEnergyCalculation
         data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] = p.Ea[p.regionIntrinsic]
     end
 
@@ -193,13 +193,8 @@ function main(;
     end
     ################################################################################
 
-    solution = equilibrium_solve!(ctsys, control = control)
+    solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = vacancyEnergyCalculation)
     inival = solution
-
-    if !EaPredefined
-        calculate_Ea!(ctsys, control = control)
-        inival = equilibrium_solve!(ctsys, control = control)
-    end
 
     if test == false
         println("*** done\n")
@@ -259,7 +254,7 @@ function main(;
 
         println("Calculated average vacancy density is: ", integral / data.regionVolumes[p.regionIntrinsic])
         println(" ")
-        if !EaPredefined
+        if vacancyEnergyCalculation
             vacancyEnergy = data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] / data.constants.q
             println("Value for vacancy energy is: ", vacancyEnergy, " eV. Save this value for later use.")
             println("We recommend to calculate it on a fine grid.")
@@ -273,8 +268,8 @@ function main(;
 end # main
 
 function test()
-    testval = -0.5965842980773581; testvalEaPredefined = -0.5967127688772338
-    return main(test = true) ≈ testval && main(test = true, EaPredefined = true) ≈ testvalEaPredefined
+    testval = -0.5965842980773581; testvalvacancyEnergyCalculation = -0.5967127688772338
+    return main(test = true) ≈ testval && main(test = true, vacancyEnergyCalculation = false) ≈ testvalvacancyEnergyCalculation
 end
 
 

--- a/examples/Ex201_PSC_tensorGrid.jl
+++ b/examples/Ex201_PSC_tensorGrid.jl
@@ -19,7 +19,7 @@ using PyPlot
 function main(;
         n = 3, Plotter = PyPlot, plotting = false, verbose = false, test = false,
         parameter_set = Params_PSC_PCBM_MAPI_Pedot, # choose the parameter set
-        EaPredefined = false,                       # assume the vacancy energy level is either on or off
+        vacancyEnergyCalculation = true,            # assume the vacancy energy level is either given or not
     )
 
     ################################################################################
@@ -167,7 +167,7 @@ function main(;
 
     data.params = Params(p)
 
-    if EaPredefined
+    if !vacancyEnergyCalculation
         data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] = p.Ea[p.regionIntrinsic]
     end
 
@@ -200,13 +200,8 @@ function main(;
     end
     ################################################################################
 
-    solution = equilibrium_solve!(ctsys, control = control)
+    solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = vacancyEnergyCalculation)
     inival = solution
-
-    if !EaPredefined
-        calculate_Ea!(ctsys, control = control)
-        inival = equilibrium_solve!(ctsys, control = control)
-    end
 
     if plotting # currently, plotting the solution was only tested with PyPlot.
         ipsi = data.index_psi
@@ -296,7 +291,7 @@ function main(;
         println(" ")
         println("Calculated average vacancy density is: ", integral / data.regionVolumes[p.regionIntrinsic])
         println(" ")
-        if !EaPredefined
+        if vacancyEnergyCalculation
             vacancyEnergy = data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] / data.constants.q
             println("Value for vacancy energy is: ", vacancyEnergy, " eV. Save this value for later use.")
             println("We recommend to calculate it on a fine grid.")
@@ -314,8 +309,8 @@ function main(;
 end #  main
 
 function test()
-    testval = -0.5815947701306688; testvalEaPredefined = -0.5823076281125769
-    return main(test = true) ≈ testval && main(test = true, EaPredefined = true) ≈ testvalEaPredefined
+    testval = -0.5815947701306688; testvalvacancyEnergyCalculation = -0.5823076281125769
+    return main(test = true) ≈ testval && main(test = true, vacancyEnergyCalculation = false) ≈ testvalvacancyEnergyCalculation
 end
 
 if test == false

--- a/examples/PSC_2D_unstructuredGrid.jl
+++ b/examples/PSC_2D_unstructuredGrid.jl
@@ -27,7 +27,7 @@ module PSC_2D_unstructuredGrid
     function main(
             Plotter = PyPlot, ; plotting = false, verbose = false, test = false,
             parameter_set = Params_PSC_PCBM_MAPI_Pedot, # choose the parameter set
-            EaPredefined = false,                       # assume the vacancy energy level is either on or off
+            vacancyEnergyCalculation = true,            # assume the vacancy energy level is either given or not
         )
 
         PyPlot.close("all")
@@ -166,7 +166,7 @@ module PSC_2D_unstructuredGrid
 
         data.params = Params(p)
 
-        if EaPredefined
+        if !vacancyEnergyCalculation
             data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] = p.Ea[p.regionIntrinsic]
         end
 
@@ -198,13 +198,8 @@ module PSC_2D_unstructuredGrid
         end
         ################################################################################
 
-        solution = equilibrium_solve!(ctsys, control = control)
+        solution = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = vacancyEnergyCalculation)
         inival = solution
-
-        if !EaPredefined
-            calculate_Ea!(ctsys, control = control)
-            inival = equilibrium_solve!(ctsys, control = control)
-        end
 
         if plotting # currently, plotting the solution was only tested with PyPlot.
             ipsi = data.index_psi
@@ -298,7 +293,7 @@ module PSC_2D_unstructuredGrid
             println(" ")
             println("Calculated average vacancy density is: ", integral / data.regionVolumes[p.regionIntrinsic])
             println(" ")
-            if !EaPredefined
+            if vacancyEnergyCalculation
                 vacancyEnergy = data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] / data.constants.q
                 println("Value for vacancy energy is: ", vacancyEnergy, " eV. Save this value for later use.")
                 println("We recommend to calculate it on a fine grid.")
@@ -312,8 +307,8 @@ module PSC_2D_unstructuredGrid
     end #  main
 
     function test()
-        testval = -0.5677056490562654; testvalEaPredefined = -0.5699122214278122
-        return main(test = true) ≈ testval && main(test = true, EaPredefined = true) ≈ testvalEaPredefined
+        testval = -0.5677056490562654; testvalvacancyEnergyCalculation = -0.5699122214278122
+        return main(test = true) ≈ testval && main(test = true, vacancyEnergyCalculation = false) ≈ testvalvacancyEnergyCalculation
     end
 
     if test == false

--- a/examples/PSC_3D.jl
+++ b/examples/PSC_3D.jl
@@ -193,17 +193,12 @@ function main(;
     end
     ################################################################################
 
-    sol1D = equilibrium_solve!(ctsys1D, control = control, nonlinear_steps = 20)
-    calculate_Ea!(ctsys1D, control = control)
-    sol1D = equilibrium_solve!(ctsys1D, control = control)
+    sol1D = equilibrium_solve!(ctsys1D, control = control, vacancyEnergyCalculation = false)
 
-    # We already did this loop to find the correct energy for the vacancies. Due to that, we just copied it here.
-    # In case you want that the solver also calculates this value, simply undo the outcommenting of the next lines.
-
-    # sol3D = equilibrium_solve!(ctsys3D, control = control, nonlinear_steps = 20)
-    # calculate_Ea!(ctsys3D, control = control)
+    # We already did the calculations to find the correct energy for the vacancies. Due to that, we just copied the value here.
     ctsys3D.data.params.bandEdgeEnergy[p.iphia, p.regionIntrinsic] = -4.461 * data3D.constants.q
-    sol3D = equilibrium_solve!(ctsys3D, control = control)
+    # In case you want that the solver also calculates this value, simply set vacancyEnergyCalculation = true.
+    sol3D = equilibrium_solve!(ctsys3D, control = control, vacancyEnergyCalculation = false)
 
     if plotting == true
         #################################################

--- a/parameter_files/Params_PSC_PCBM_MAPI_Pedot.jl
+++ b/parameter_files/Params_PSC_PCBM_MAPI_Pedot.jl
@@ -67,19 +67,17 @@
     ## band edge energies
     En = [-3.8, -3.8, -3.0] .* eV
     Ep = [-6.2, -5.4, -5.1] .* eV
-    Ea = [0.0, -4.66, 0.0] .* eV
+    Ea = [0.0, -4.657, 0.0] .* eV
 
     ## effective densities of density of states
     Nn = [1.0e25, 1.0e25, 1.0e26] ./ (m^3)
     Np = [1.0e25, 1.0e25, 1.0e26] ./ (m^3)
     Na = [0.0, 1.0e26, 0.0] ./ (m^3)
 
-
     ## mobilities
     μn = [1.0e-7, 2.0e-3, 1.0e-5] .* (m^2) / (V * s)
     μp = [1.0e-7, 2.0e-3, 1.0e-5] .* (m^2) / (V * s)
     μa = [0.0, 1.0e-14, 0.0] .* (m^2) / (V * s)
-
 
     ## relative dielectric permittivity
     ε = [3.0, 23.0, 4.0] .* 1.0
@@ -137,7 +135,6 @@ function Params(p::Params_PSC_PCBM_MAPI_Pedot)
 
     params.bandEdgeEnergy[p.iphin, :] = p.En
     params.bandEdgeEnergy[p.iphip, :] = p.Ep
-    params.bandEdgeEnergy[p.iphia, :] = p.Ea
 
     params.mobility[p.iphin, :] = p.μn
     params.mobility[p.iphip, :] = p.μp

--- a/parameter_files/Params_PSC_TiO2_MAPI_spiro.jl
+++ b/parameter_files/Params_PSC_TiO2_MAPI_spiro.jl
@@ -66,7 +66,7 @@
     ## band edge energies
     En = [-4.0, -3.7, -3.4] .* eV
     Ep = [-5.8, -5.4, -5.1] .* eV
-    Ea = [0.0, -4.45, 0.0] .* eV
+    Ea = [0.0, -4.437, 0.0] .* eV
     Ea_i = Ea[regionIntrinsic]
 
     ## effective densities of density of states
@@ -135,7 +135,6 @@ function Params(p::Params_PSC_TiO2_MAPI_spiro)
 
         params.bandEdgeEnergy[p.iphin, ireg] = p.En[ireg]
         params.bandEdgeEnergy[p.iphip, ireg] = p.Ep[ireg]
-        params.bandEdgeEnergy[p.iphia, ireg] = p.Ea[ireg]
 
         params.mobility[p.iphin, ireg] = p.μn[ireg]
         params.mobility[p.iphip, ireg] = p.μp[ireg]

--- a/src/ChargeTransport.jl
+++ b/src/ChargeTransport.jl
@@ -95,7 +95,7 @@ export BulkRecombination, set_bulk_recombination
 
 export enable_ionic_carrier!
 
-export equilibrium_solve!, calculate_Ea!
+export equilibrium_solve!
 export enable_species!, enable_boundary_species!
 export solve
 export unknowns, NewtonControl, SolverControl

--- a/src/ChargeTransport.jl
+++ b/src/ChargeTransport.jl
@@ -95,7 +95,7 @@ export BulkRecombination, set_bulk_recombination
 
 export enable_ionic_carrier!
 
-export equilibrium_solve!
+export equilibrium_solve!, calculate_Ea!
 export enable_species!, enable_boundary_species!
 export solve
 export unknowns, NewtonControl, SolverControl
@@ -107,7 +107,7 @@ export set_contact!
 export compute_open_circuit_voltage
 export electroNeutralSolution
 export show_params, show_paramsoptical, trap_density
-export get_current_val, charge_density
+export get_current_val, charge_density, integrated_density
 
 ##################################################################
 

--- a/src/ct_system.jl
+++ b/src/ct_system.jl
@@ -1752,7 +1752,9 @@ function _equilibrium_solve!(::Val{true}, ctsys::System; inival, control, nonlin
 
                 x_new, y_new = save_eval_F(F, x_new, icc, ireg)
 
-                # println("iter $k: x_new=$(x_new / q), y_new=$y_new")
+                if control.verbose
+                    println("Energy calculation: iter $k: x_new=$(x_new / q), y_new=$y_new")
+                end
 
                 # stopping criterion
                 if abs(y_new) < ytol

--- a/src/ct_system.jl
+++ b/src/ct_system.jl
@@ -1682,7 +1682,7 @@ function _equilibrium_solve!(::Val{true}, ctsys::System; inival, control, nonlin
                 E_new = round(((params.bandEdgeEnergy[icc, ireg] / q) - 1.0e-4), digits = 4) * q
                 params.bandEdgeEnergy[icc, ireg] = E_new
                 # println("        save solve")
-                # println("            ", Enew / q)
+                # println("            ", E_new / q)
 
             end
         end


### PR DESCRIPTION
## Summary
This feature makes it possible to calculate the **vacancy energy level** for perovskite solar cell applications internally.  
---

## New Features
- Modified `equilibrium_solve!()`.   
  → Directly computes now the correct energy level such that the average vacancy density matches the user-defined target, if the argument is `vacancyEnergyCalculation = true`. 
 → Included loop for increasing photogeneration also here.

- Added method `integrated_density`  
  → Computes the integrated carrier density for a given species `icc` and region `ireg`  

- Extended `Data` structure with `data.regionVolumes`  
  → Stores the volume (measure) of each subregion  

---

## Example Usage

```julia
# Compute vacancy energy level automatically
sol = equilibrium_solve!(ctsys, control = control, vacancyEnergyCalculation = true)

# Compute integrated density for a carrier species, e.g.
n_int = integrated_density(ctsys, sol = sol, icc = iphia, ireg = regionIntrinsic)

println("Energy level: ", data.params.bandEdgeEnergy[iphia, regionIntrinsic]/data.constants.q) # in eV
println("Integrated density: ", n_int/data.regionVolumes[regionIntrinsic])
